### PR TITLE
Fix short response parsing and change default model to gemini-2.0-flash

### DIFF
--- a/src/gemini_code_sdk/_internal/client.py
+++ b/src/gemini_code_sdk/_internal/client.py
@@ -94,6 +94,15 @@ class InternalClient:
                 
         except Exception as e:
             logger.error(f"Query processing failed: {e}")
+            # Emit error message before re-raising
+            yield ResultMessage(
+                subtype="error_during_execution",
+                duration_ms=0,
+                is_error=True,
+                session_id="error",
+                num_turns=0,
+                result=str(e)
+            )
             raise
         finally:
             # Ensure transport is disconnected

--- a/src/gemini_code_sdk/_internal/client.py
+++ b/src/gemini_code_sdk/_internal/client.py
@@ -71,7 +71,7 @@ class InternalClient:
             yield SystemMessage(
                 subtype="init",
                 data={
-                    "model": options.model or "gemini-2.5-pro",
+                    "model": options.model or os.getenv("GEMINI_MODEL", "gemini-2.0-flash"),
                     "cwd": str(options.cwd) if options.cwd else os.getcwd(),
                     "parser": type(self.parser).__name__,
                     "sandbox": options.sandbox,

--- a/src/gemini_code_sdk/_internal/parser/llm_parser.py
+++ b/src/gemini_code_sdk/_internal/parser/llm_parser.py
@@ -99,8 +99,8 @@ class LLMParser(ParserStrategy):
             if cached:
                 return cached.copy()
         
-        # Handle empty or very short responses
-        if not cleaned_output or len(cleaned_output.strip()) < 3:
+        # Handle empty responses
+        if not cleaned_output or not cleaned_output.strip():
             return messages
         
         # Quick check for simple numeric/single word responses

--- a/src/gemini_code_sdk/_internal/transport/subprocess_cli.py
+++ b/src/gemini_code_sdk/_internal/transport/subprocess_cli.py
@@ -161,12 +161,7 @@ class SubprocessCLITransport(Transport):
             # Read stdout
             if self._process.stdout:
                 try:
-                    stdout_data = await self._process.stdout.receive()
-                    # Continue reading until EOF
-                    while True:
-                        chunk = await self._process.stdout.receive()
-                        if not chunk:
-                            break
+                    async for chunk in self._process.stdout:
                         stdout_data += chunk
                 except anyio.EndOfStream:
                     pass
@@ -174,11 +169,7 @@ class SubprocessCLITransport(Transport):
             # Read stderr
             if self._process.stderr:
                 try:
-                    stderr_data = await self._process.stderr.receive()
-                    while True:
-                        chunk = await self._process.stderr.receive()
-                        if not chunk:
-                            break
+                    async for chunk in self._process.stderr:
                         stderr_data += chunk
                 except anyio.EndOfStream:
                     pass
@@ -189,6 +180,15 @@ class SubprocessCLITransport(Transport):
             # Decode output
             stdout = stdout_data.decode('utf-8', errors='replace')
             stderr = stderr_data.decode('utf-8', errors='replace')
+            
+            # Debug logging
+            logger.debug(f"Process completed with return code: {returncode}")
+            logger.debug(f"Stdout length: {len(stdout)}")
+            logger.debug(f"Stderr length: {len(stderr)}")
+            if stdout:
+                logger.debug(f"Stdout preview: {stdout[:200]}...")
+            if stderr:
+                logger.debug(f"Stderr preview: {stderr[:200]}...")
             
             # Check for errors
             if returncode != 0:


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where short responses were being ignored and updates the default model to a more cost-effective option.

## Changes

### 1. Fix Parser Bug for Short Responses
- **Issue**: Responses shorter than 3 characters (like "4", "OK", "Hi") were silently dropped
- **Root Cause**: Arbitrary length check in the LLM parser (`len(cleaned_output.strip()) < 3`)
- **Fix**: Only skip truly empty responses, not short valid ones

### 2. Change Default Model to gemini-2.0-flash
- **Previous**: gemini-2.5-pro (more expensive)
- **New**: gemini-2.0-flash (more cost-effective)
- **Flexibility**: Respects `GEMINI_MODEL` environment variable
- **Precedence**: GeminiOptions.model > GEMINI_MODEL env > default

## Testing

Tested with various short responses:
- "4" ✓
- "OK" ✓
- "Hi" ✓
- "42" ✓

All now parse correctly instead of returning empty message lists.

## Impact

- Fixes silent failures for simple queries
- Reduces API costs by defaulting to cheaper model
- Maintains backward compatibility through environment variable support